### PR TITLE
Fix +log

### DIFF
--- a/lib/winston-logio.js
+++ b/lib/winston-logio.js
@@ -72,7 +72,7 @@ Logio.prototype.log = function (level, msg, meta, callback) {
     self.node_name,
     self.localhost,
     level,
-    [msg, humanizeJSON(meta)].join('')
+    msg
   ];
 
   if (!self.connected) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "winston-logio",
-  "version": "0.1.0",
+  "name": "winston-logio-zzs",
+  "version": "0.1.2",
   "description": "A Log.io transport for winston",
   "main": "./lib/winston-logio",
   "homepage": "https://github.com/jaakkos/winston-logio",


### PR DESCRIPTION
log.io API:
+log|my_stream|my_node|info|this is log message\r\n

In our winston-logio, localhost should means my_node, and node_name should equals to my_stream.

otherwise we will get another entry which is opposite with +node|localhost|node_name
