### PR TITLE
endless reconnects

### DIFF
--- a/lib/winston-logio.js
+++ b/lib/winston-logio.js
@@ -68,7 +68,7 @@ Logio.prototype.log = function (level, msg, meta, callback) {
 
   // Log format
   log_entry = [
-    '+log',    
+    '+log',
     self.node_name,
     self.localhost,
     level,
@@ -97,6 +97,7 @@ Logio.prototype.connect = function () {
 
   this.socket.on('error', function (err) {
     self.connected = false;
+    self.error = true
     self.socket.destroy();
 
     if (self.retries < 3) {
@@ -119,7 +120,12 @@ Logio.prototype.connect = function () {
 
   this.socket.on('close', function () {
     self.connected = false;
-    self.connect();
+    if (self.error == false) {
+      self.connect();
+    } else {
+      self.error = true;
+    }
+
   });
 
   this.socket.connect(self.port, self.host, function () {

--- a/lib/winston-logio.js
+++ b/lib/winston-logio.js
@@ -109,6 +109,10 @@ Logio.prototype.connect = function () {
     } else {
       self.log_queue = [];
       self.silent = true;
+      setTimeout(function() {
+        self.silent = false;
+        self.connect();
+      }, 5000);
     }
   });
 

--- a/lib/winston-logio.js
+++ b/lib/winston-logio.js
@@ -110,6 +110,7 @@ Logio.prototype.connect = function () {
       self.log_queue = [];
       self.silent = true;
       setTimeout(function() {
+        self.retries = 0;
         self.silent = false;
         self.connect();
       }, 5000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-logio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Log.io transport for winston",
   "main": "./lib/winston-logio",
   "homepage": "https://github.com/jaakkos/winston-logio",
@@ -40,6 +40,10 @@
     {
       "name": "Jaakko Suutarla",
       "email": "jaakko@suutarla.com"
+    },
+    {
+      "name": "Michael Poschacher",
+      "email": "michael.poschacher@gmail.com"
     }
   ],
   "maintainers": [


### PR DESCRIPTION
According to http://nodejs.org/api/net.html#net_event_error the `close` event is fired after the `error` event. This causes endless connects and takes a lot of CPU. (I added a 5s timeout to force a connect if server isn't reachable)