### PR TITLE
Add support for multiple transport instances

### DIFF
--- a/lib/winston-logio.js
+++ b/lib/winston-logio.js
@@ -14,7 +14,7 @@ var Logio = exports.Logio = function (options) {
   winston.Transport.call(this, options);
   options = options || {};
 
-  this.name       = 'logio';
+  this.name       = options.name || 'logio';
   this.localhost  = options.localhost || os.hostname();
   this.host       = options.host || '127.0.0.1';
   this.port       = options.port || 28777;


### PR DESCRIPTION
Wiston allow to specify differents name for the same transport like this:

```javascript
        new winston.transports.Logio({
            port: 28777,
            name: 'logio.info',
            node_name: 'Dicet',
            host: '127.0.0.1',
            level: 'info',
            localhost: 'info'
        }),
        new winston.transports.Logio({
            port: 28777,
            name: 'logio.verbose',
            node_name: 'Dicet',
            host: '127.0.0.1',
            level: 'verbose',
            localhost: 'verbose'
        }),
        new winston.transports.Logio({
            port: 28777,
            name: 'logio.debug',
            node_name: 'Dicet',
            host: '127.0.0.1',
            level: 'debug',
            localhost: 'debug'
        })
```

Doing this we can create multiple transport instances.